### PR TITLE
feat(ApolloQueryPipe): first property of data by default

### DIFF
--- a/examples/hello-world/client/main.html
+++ b/examples/hello-world/client/main.html
@@ -8,7 +8,7 @@
 <h2>List</h2>
 
 <ul>
-  <li *ngFor="let user of users | async | apolloQuery:'users'">
+  <li *ngFor="let user of users | async | apolloQuery">
     {{ user.firstName }} {{ user.lastName }}
   </li>
 </ul>

--- a/examples/hello-world/client/main.ts
+++ b/examples/hello-world/client/main.ts
@@ -23,7 +23,7 @@ import ApolloClient, {
 import gql from 'apollo-client/gql';
 
 import {
-  graphQLResult
+  graphQLResult,
 } from 'graphql';
 
 const client = new ApolloClient({
@@ -89,9 +89,10 @@ const client = new ApolloClient({
   },
 })
 class Main {
-  users: Observable<any[]>;
-  firstName: string;
-  lastName: string;
+  public addUser: Function;
+  public users: Observable<any[]>;
+  public firstName: string;
+  public lastName: string;
 
   public newUser() {
     this.addUser(this.firstName)

--- a/src/apolloQueryPipe.ts
+++ b/src/apolloQueryPipe.ts
@@ -4,12 +4,29 @@ import {
   Pipe,
 } from '@angular/core';
 
+import {
+  values,
+  isEmpty,
+  isObject,
+} from 'lodash';
+
 @Pipe({
   name: 'apolloQuery',
 })
 export class ApolloQueryPipe {
   public transform(obj: any, name: string = '') {
-    if (obj && obj.data && name !== '' && obj.data[name]) {
+    if (!isObject(obj)) {
+      return;
+    }
+
+    // an empty object by default
+    obj = (obj || {});
+
+    if (isEmpty(name)) {
+      return values(obj.data)[0];
+    }
+
+    if (obj.data) {
       return obj.data[name];
     }
   }

--- a/tests/apolloQueryPipe.ts
+++ b/tests/apolloQueryPipe.ts
@@ -7,14 +7,35 @@ describe('ApolloQueryPipe', () => {
     pipe = new ApolloQueryPipe();
   });
 
-  it('should capitalize all words in a string', () => {
-    const object = {
-      data: {
-        foo: 'bar',
-      },
-    };
-    const result = pipe.transform(object, 'foo');
+  it('should return nothing if first argument is not an object', () => {
+    expect(pipe.transform('test')).toBeUndefined();
+  });
 
-    expect(result).toEqual(object.data.foo);
+  it('should return nothing on empty object', () => {
+    expect(pipe.transform({})).toBeUndefined();
+  });
+
+  it('should return nothing on empty data', () => {
+    expect(pipe.transform({
+      data: {},
+    })).toBeUndefined();
+  });
+
+  it('should use the first property of data if name is not defined', () => {
+    expect(pipe.transform({
+      data: {
+        foo: 'foo',
+        bar: 'bar',
+      },
+    })).toEqual('foo');
+  });
+
+  it('should use a property where key matches name', () => {
+    expect(pipe.transform({
+      data: {
+        foo: 'foo',
+        bar: 'bar',
+      },
+    }, 'bar')).toEqual('bar');
   });
 });


### PR DESCRIPTION
We don't have to specify the property key of data object.

+ few tests of AngularQueryPipe
+ code is now much cleaner

Now it works like this:
```html
<li *ngFor="#user of users | async | apolloQuery">
     {{ user.firstName }} {{ user.lastName }}
</li>
```

Instead of this:

```html
<li *ngFor="#user of users | async | apolloQuery:'users'">
     {{ user.firstName }} {{ user.lastName }}
</li>
```