### PR TITLE
feat(ApolloQueryPipe): Support both results from decorator and service

### DIFF
--- a/src/apolloQueryPipe.ts
+++ b/src/apolloQueryPipe.ts
@@ -9,8 +9,16 @@ import {
 })
 export class ApolloQueryPipe {
   public transform(obj: any, name: string = '') {
-    if (obj && obj.data && name !== '' && obj.data[name]) {
-      return obj.data[name];
+    if (obj && name !== '') {
+      // for Apollo decorator
+      if (obj[name]) {
+        return obj[name];
+      }
+
+      // for Angular2Apollo.watchQuery
+      if (obj.data && obj.data[name]) {
+        return obj.data[name];
+      }
     }
   }
 }

--- a/tests/apolloQueryPipe.ts
+++ b/tests/apolloQueryPipe.ts
@@ -1,4 +1,6 @@
-import {ApolloQueryPipe} from '../src/apolloQueryPipe';
+import {
+  ApolloQueryPipe,
+} from '../src';
 
 describe('ApolloQueryPipe', () => {
   let pipe: ApolloQueryPipe;
@@ -7,14 +9,33 @@ describe('ApolloQueryPipe', () => {
     pipe = new ApolloQueryPipe();
   });
 
-  it('should capitalize all words in a string', () => {
-    const object = {
-      data: {
-        foo: 'bar',
-      },
-    };
-    const result = pipe.transform(object, 'foo');
+  it('should return nothing if name is empty', () => {
+    expect(pipe.transform({ foo: 'bar' }, '')).toBe(undefined);
+  });
 
-    expect(result).toEqual(object.data.foo);
+  it('should return nothing if object is empty', () => {
+    expect(pipe.transform({}, 'foo')).toBe(undefined);
+  });
+
+  it('should return nothing if object is missing', () => {
+    expect(pipe.transform(undefined, 'foo')).toBe(undefined);
+  });
+
+  it('should return nothing if nothing has been found', () => {
+    expect(pipe.transform({ foo: 'bar' }, 'baz')).toBe(undefined);
+  });
+
+  it('should be looking directly on object if the result comes from Apollo decorator', () => {
+    const result = { foo: 'bar' };
+
+    expect(pipe.transform(result, 'foo')).toEqual(result.foo);
+  });
+
+  it('should be looking inside data property iif the result comes fromf Angular2Apollo', () => {
+    const result = {
+      data: { foo: 'bar' },
+    };
+
+    expect(pipe.transform(result, 'foo')).toEqual(result.data.foo);
   });
 });


### PR DESCRIPTION
It allows to use `ApolloQueryPipe` with `@Apollo` and `Angular2Apollo.watchQuery()`.

```html
<ul>
  <li *ngFor="let post of data | apolloQuery:'posts'">
      {{ post.title }}
  </li>
</ul>
```