### PR TITLE
docs: Add change log and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md.md
@@ -1,0 +1,13 @@
+<!--
+  Thanks for filing a pull request on Apollo Client!
+
+  Please look at the following checklist to ensure that your PR
+  can be accepted quickly:
+-->
+
+TODO:
+
+- [ ] Update CHANGELOG.md with your change
+- [ ] Make sure all of the significant new logic is covered by tests
+- [ ] Rebase your changes on master so that they can be merged easily
+- [ ] Make sure all tests and linter rules pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Change log
+
+### vNEXT
+
+- Added SSR support
+- Left `lodash` as the only one dependency and `@angular/core` with `apollo-client` as peerDependecies ([PR #29](https://github.com/apollostack/angular2-apollo/pull/29))
+- Fixed missing data in reused component ([PR #30](https://github.com/apollostack/angular2-apollo/pull/30))
+
+### v0.2.0
+
+- Added polling, refetching and access to unsubscribe method ([PR #19](https://github.com/apollostack/angular2-apollo/pull/19))
+- Added `forceFetch`, `returnPartialData` and `pollInterval` support ([PR #19](https://github.com/apollostack/angular2-apollo/pull/19))
+- Added `errors` and `loading` to the query's result object ([PR #19](https://github.com/apollostack/angular2-apollo/pull/19))
+- Added both results from decorator and service support for `ApolloQueryPipe` ([PR #27](https://github.com/apollostack/angular2-apollo/pull/27))
+- Fixed issue with not setting a query with not defined variables ([PR #19](https://github.com/apollostack/angular2-apollo/pull/19))
+
+### v0.1.0
+
+- Added Angular2 RC1 and ApolloClient 0.3.X support ([PR #16](https://github.com/apollostack/angular2-apollo/pull/16), [PR #17](https://github.com/apollostack/angular2-apollo/pull/17))
+
+### v0.0.2
+
+- Added `@Apollo` decorator ([99fed6e](https://github.com/apollostack/angular2-apollo/commit/99fed6e), [9f0107e](https://github.com/apollostack/angular2-apollo/commit/9f0107e))
+
+
+### v0.0.1
+
+Initial release. We didn't track changes before this version.


### PR DESCRIPTION
PR template is exactly the same as apollo-client's

Changelog has the same structure as other apollostack projects