### PR TITLE
refactor(Apollo): pass all options to mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### vNEXT
+
+- Passing all the options of mutation in `Apollo` decorator [PR #39](https://github.com/apollostack/angular2-apollo/pull/39)
+
 ### v0.3.0
 
 - Added SSR support

--- a/src/apolloDecorator.ts
+++ b/src/apolloDecorator.ts
@@ -142,9 +142,9 @@ class ApolloHandle {
   private createMutation(mutationName: string, method: Function) {
     // assign to component's context
     this.component[mutationName] = (...args): Promise<GraphQLResult> => {
-      const { mutation, variables } = method.apply(this.client, args);
+      const options = method.apply(this.client, args);
 
-      return this.client.mutate({ mutation, variables });
+      return this.client.mutate(options);
     };
   }
 


### PR DESCRIPTION
Instead of passing just `mutation` and `variables`