### PR TITLE
chore: Update apollo-client to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/apollostack/angular2-apollo#readme",
   "dependencies": {
     "@angular/core": "^2.0.0-rc.1",
-    "apollo-client": "^0.3.0",
+    "apollo-client": "^0.4.0",
     "graphql-tag": "^0.1.7",
     "lodash": "^4.11.1"
   },

--- a/src/apolloDecorator.ts
+++ b/src/apolloDecorator.ts
@@ -161,9 +161,9 @@ class ApolloHandle {
         errors,
         loading: false,
         unsubscribe: () => this.getQuery(queryName).unsubscribe(),
-        refetch: (...args) => this.getQuery(queryName).refetch(...args),
-        stopPolling: () => this.getQuery(queryName).stopPolling(),
-        startPolling: (...args) => this.getQuery(queryName).startPolling(...args),
+        refetch: (...args) => obs.refetch(...args),
+        stopPolling: () => obs.stopPolling(),
+        startPolling: (...args) => obs.startPolling(...args),
       }, changed ? data : {});
     };
 


### PR DESCRIPTION
This pull request updated apollo-client to 0.4.0 because I get some TypeScript problems when using 0.4.0 and the angular2-apollo uses 0.3.0.