### PR TITLE
ApolloQuery interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Passing all the options of mutation in `Apollo` decorator [PR #39](https://github.com/apollostack/angular2-apollo/pull/39)
 - Added support for `apollo-client` breaking change that moves methods to query's observable ([PR #40](https://github.com/apollostack/angular2-apollo/pull/40))
 - Replaced `lodash` with subpackages, removed `graphql-tag` from dependencies, moved `apollo-client` and `@angular/core` to peerDependecies ([PR #44](https://github.com/apollostack/angular2-apollo/pull/44))
+- Added `ApolloQuery` interface ([PR #45](https://github.com/apollostack/angular2-apollo/pull/45))
 
 ### v0.3.0
 

--- a/examples/hello-world/client/main.ts
+++ b/examples/hello-world/client/main.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   Apollo,
+  ApolloQuery,
 } from 'angular2-apollo';
 
 import ApolloClient, {
@@ -88,7 +89,7 @@ const client = new ApolloClient({
   },
 })
 class Main {
-  public data: any;
+  public data: ApolloQuery;
   public firstName: string;
   public lastName: string;
   public nameFilter: string;

--- a/src/apolloDecorator.ts
+++ b/src/apolloDecorator.ts
@@ -2,9 +2,22 @@ import ApolloClient, {
   ApolloQueryResult,
 } from 'apollo-client';
 
+import {
+  ApolloError,
+} from 'apollo-client/errors';
+
 import isEqual = require('lodash.isequal');
 import forIn = require('lodash.forin');
 import assign = require('lodash.assign');
+
+export interface ApolloQuery {
+  errors: ApolloError;
+  loading: boolean;
+  refetch: (variables?: any) => Promise<ApolloQueryResult>;
+  stopPolling: () => void;
+  startPolling: (pollInterval: number) => void;
+  unsubscribe: () => void;
+}
 
 export interface ApolloOptions {
   client: ApolloClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
 
 import {
   Apollo,
+  ApolloQuery,
 } from './apolloDecorator';
 
 import {
@@ -17,6 +18,7 @@ export const APOLLO_PROVIDERS: any[] = [
 
 export {
   Apollo,
+  ApolloQuery,
   ApolloQueryPipe,
   Angular2Apollo,
   defaultApolloClient


### PR DESCRIPTION
Before:

```ts
class App {
  data: any; // to avoid typescript errors
  
  update(): void {
    this.data.refetch();
  }
}
```

After:

```ts
class App {
  data: ApolloQuery; // contains refetch method
  
  update(): void {
    this.data.refetch();
  }
}
```

We could also:

```ts
interface DataQuery extends ApolloQuery {
  hero: Hero
}

class App {
  data: DataQuery;

  print(): void {
    console.log(this.data.hero); // no error :)
  }
  
  update(): void {
    this.data.refetch();
  }
}
```