### PR TITLE
Fetch more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Added `fetchMore` support ([PR #58](https://github.com/apollostack/angular2-apollo/pull/58))
+
 ### v0.4.1
 
 - Added `ApolloQueryObservable` to support `Rx.Observable` in `Angular2Apollo.watchQuery` method ([PR #52](https://github.com/apollostack/angular2-apollo/pull/52))

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@angular/core": "^2.0.0-rc.1",
     "@angular/platform-browser": "^2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
-    "apollo-client": "^0.4.1",
+    "apollo-client": "^0.4.11",
     "es6-shim": "^0.35.0",
     "ghooks": "^1.2.1",
     "graphql": "^0.5.0",

--- a/src/apolloDecorator.ts
+++ b/src/apolloDecorator.ts
@@ -175,6 +175,14 @@ class ApolloHandle {
     return this.getQuery(queryName)[method](...args);
   }
 
+  private missingCompat(queryName: string, method: string, args?) {
+    if (!this.getQuery(queryName)[method]) {
+      throw new Error(`Your version of the ApolloClient does not support '${method}'. Try to update.`);
+    }
+
+    return this.getQuery(queryName)[method](...args);
+  }
+
   private subscribe(queryName: string, obs: any) {
     this.component[queryName] = {
       errors: null,
@@ -191,6 +199,7 @@ class ApolloHandle {
         refetch: (...args) => this.backcompat(queryName, 'refetch', args),
         stopPolling: () => this.backcompat(queryName, 'stopPolling'),
         startPolling: (...args) => this.backcompat(queryName, 'startPolling', args),
+        fetchMore: (...args) => this.missingCompat(queryName, 'fetchMore', args),
       }, changed ? data : {});
     };
 

--- a/tests/apolloDecorator/queries.ts
+++ b/tests/apolloDecorator/queries.ts
@@ -253,6 +253,20 @@ describe('Apollo - decorator - queries()', () => {
         done();
       }, 200);
     });
+
+    it('should be able to fetch more', (done) => {
+      component.ngOnInit();
+
+      setTimeout(() => {
+        expect(typeof component.data.fetchMore).toEqual('function');
+
+        const spy = spyOn(component.__apolloHandle.getQuery('data'), 'fetchMore');
+        component.data.fetchMore(1234);
+
+        expect(spy).toHaveBeenCalledWith(1234);
+        done();
+      }, 200);
+    });
   });
 
   it('should unsubscribe all queries on ngOnDestroy', (done) => {

--- a/typings.json
+++ b/typings.json
@@ -2,7 +2,8 @@
   "globalDependencies": {
     "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
     "isomorphic-fetch": "registry:dt/isomorphic-fetch#0.0.0+20160524142046",
-    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255"
+    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
+    "node": "registry:env/node#6.0.0+20160723033700"
   },
   "dependencies": {
     "graphql": "registry:npm/graphql#0.5.0+20160602041655",


### PR DESCRIPTION
Via https://github.com/apollostack/apollo-client/blob/master/CHANGELOG.md#v049:

> Add a new experimental feature to observable queries called `fetchMore`. It allows application developers to update the results of a query in the store by issuing new queries. We are currently testing this feature internally and we will document it once it is stable. [PR #472](https://github.com/apollostack/apollo-client/pull/472).