### PR TITLE
Query's variables as Observables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 - Added `ApolloModule` (with RC5 of Angular2 comes NgModules) ([PR #63](https://github.com/apollostack/angular2-apollo/pull/63))
+- Added ability to use query variables as observables. With this, the query can be automatically re-run when those obserables emit new values. ([PR #64]((https://github.com/apollostack/angular2-apollo/pull/64)))
 
 ### v0.4.2
 

--- a/examples/hello-world/client/imports/app.component.html
+++ b/examples/hello-world/client/imports/app.component.html
@@ -7,7 +7,7 @@
 
 <h2>List</h2>
 
-<input type="search" placeholder="Type name..." [(ngModel)]="nameFilter" />
+<input type="search" placeholder="Type name..." [formControl]="nameControl" />
 
 <ul>
   <li *ngFor="let user of data | async | apolloQuery: 'users'">

--- a/examples/hello-world/client/imports/app.module.ts
+++ b/examples/hello-world/client/imports/app.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule  } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ApolloModule } from 'angular2-apollo';
 
 import { AppComponent } from './app.component';
@@ -11,6 +11,7 @@ import { client } from './client';
   imports: [
     BrowserModule,
     FormsModule,
+    ReactiveFormsModule,
     ApolloModule.withClient(client),
   ],
   bootstrap: [ AppComponent ],

--- a/global.d.ts
+++ b/global.d.ts
@@ -12,3 +12,8 @@ declare module 'lodash.assign' {
   import main = require('~lodash/index');
   export = main.assign;
 }
+
+declare module 'lodash.omit' {
+  import main = require('~lodash/index');
+  export = main.omit;
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "lodash.assign": "^4.0.9",
     "lodash.forin": "^4.2.0",
-    "lodash.isequal": "^4.2.0"
+    "lodash.isequal": "^4.2.0",
+    "lodash.omit": "^4.4.1"
   },
   "devDependencies": {
     "@angular/common": "^2.0.0-rc.5",

--- a/src/apolloQueryObservable.ts
+++ b/src/apolloQueryObservable.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
 import { Operator } from 'rxjs/Operator';
+import { ApolloQueryResult } from 'apollo-client';
 
 import { ObservableQueryRef, IObservableQuery } from './utils/observableQuery';
 
@@ -21,19 +22,19 @@ export class ApolloQueryObservable<T> extends Observable<T> implements IObservab
 
   // apollo-specific methods
 
-  public refetch(variables) {
+  public refetch(variables?: any): Promise<ApolloQueryResult> {
     return this.apollo.refetch(variables);
   }
 
-  public stopPolling() {
+  public stopPolling(): void {
     return this.apollo.stopPolling();
   }
 
-  public startPolling(p) {
+  public startPolling(p: number): void {
     return this.apollo.startPolling(p);
   }
 
-  public fetchMore(options) {
+  public fetchMore(options: any): Promise<any> {
     return this.apollo.fetchMore(options);
   }
 }

--- a/src/apolloQueryObservable.ts
+++ b/src/apolloQueryObservable.ts
@@ -2,13 +2,11 @@ import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
 import { Operator } from 'rxjs/Operator';
-import { $$observable } from 'rxjs/symbol/observable';
 
-import { FetchMoreOptions } from 'apollo-client/ObservableQuery';
-import { FetchMoreQueryOptions } from 'apollo-client/watchQueryOptions';
+import { ObservableQueryRef, IObservableQuery } from './utils/observableQuery';
 
-export class ApolloQueryObservable<T> extends Observable<T> {
-  constructor(public apollo: any, subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
+export class ApolloQueryObservable<T> extends Observable<T> implements IObservableQuery  {
+  constructor(public apollo: ObservableQueryRef, subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
     super(subscribe);
   }
 
@@ -23,26 +21,19 @@ export class ApolloQueryObservable<T> extends Observable<T> {
 
   // apollo-specific methods
 
-  public refetch(variables?: any): Promise<any> {
+  public refetch(variables) {
     return this.apollo.refetch(variables);
   }
 
-  public stopPolling(): void {
+  public stopPolling() {
     return this.apollo.stopPolling();
   }
 
-  public startPolling(p: number): void {
+  public startPolling(p) {
     return this.apollo.startPolling(p);
   }
 
-  public fetchMore(options: FetchMoreQueryOptions & FetchMoreOptions): Promise<any> {
+  public fetchMore(options) {
     return this.apollo.fetchMore(options);
-  }
-
-  // where magic happens
-
-  protected _subscribe(subscriber: Subscriber<T>) {
-    const apollo = this.apollo;
-    return apollo[$$observable]().subscribe(subscriber);
   }
 }

--- a/src/utils/observableQuery.ts
+++ b/src/utils/observableQuery.ts
@@ -1,0 +1,34 @@
+import {
+  ObservableQuery,
+} from 'apollo-client/ObservableQuery';
+
+import {
+  ApolloQueryResult,
+} from 'apollo-client';
+
+export interface IObservableQuery {
+  refetch: (variables?: any) => Promise<ApolloQueryResult>;
+  fetchMore: (options: any) => Promise<any>;
+  stopPolling: () => void;
+  startPolling: (p: number) => void;
+}
+
+export class ObservableQueryRef implements IObservableQuery {
+  public apollo: ObservableQuery;
+
+  public refetch(variables) {
+    return this.apollo.refetch(variables);
+  }
+
+  public stopPolling() {
+    return this.apollo.stopPolling();
+  }
+
+  public startPolling(p) {
+    return this.apollo.startPolling(p);
+  }
+
+  public fetchMore(options) {
+    return this.apollo.fetchMore(options);
+  }
+}

--- a/src/utils/observableQuery.ts
+++ b/src/utils/observableQuery.ts
@@ -16,19 +16,19 @@ export interface IObservableQuery {
 export class ObservableQueryRef implements IObservableQuery {
   public apollo: ObservableQuery;
 
-  public refetch(variables) {
+  public refetch(variables?: any): Promise<ApolloQueryResult> {
     return this.apollo.refetch(variables);
   }
 
-  public stopPolling() {
+  public stopPolling(): void {
     return this.apollo.stopPolling();
   }
 
-  public startPolling(p) {
+  public startPolling(p: number): void {
     return this.apollo.startPolling(p);
   }
 
-  public fetchMore(options) {
+  public fetchMore(options: any): Promise<any> {
     return this.apollo.fetchMore(options);
   }
 }

--- a/src/utils/observeVariables.ts
+++ b/src/utils/observeVariables.ts
@@ -1,0 +1,41 @@
+import { Observable } from 'rxjs/Observable';
+import { Observer } from 'rxjs/Observer';
+
+import 'rxjs/add/observable/combineLatest';
+
+export function observeVariables(variables?: Object): Observable<Object> {
+  const keys = Object.keys(variables);
+
+  return Observable.create((observer: Observer<any>) => {
+    Observable.combineLatest(mapVariablesToObservables(variables))
+      .subscribe((values) => {
+        const resultVariables = {};
+
+        values.forEach((value, i) => {
+          const key = keys[i];
+          resultVariables[key] = value;
+        });
+
+        observer.next(resultVariables);
+      });
+  });
+};
+
+function mapVariablesToObservables(variables?: Object) {
+  return Object.keys(variables)
+    .map(key => getVariableToObservable(variables[key]));
+}
+
+function getVariableToObservable(variable: any | Observable<any>) {
+  if (variable instanceof Observable) {
+    return variable;
+  } else if (typeof variable !== 'undefined') {
+    return new Observable<any>(subscriber => {
+      subscriber.next(variable);
+    });
+  } else {
+    return new Observable<any>(subscriber => {
+      subscriber.next(undefined);
+    });
+  }
+}

--- a/tests/apolloQueryObservable.ts
+++ b/tests/apolloQueryObservable.ts
@@ -3,10 +3,15 @@ import {
 } from '../src/apolloQueryObservable';
 
 import {
+  ObservableQueryRef,
+} from '../src/utils/observableQuery';
+
+import {
   mockClient,
 } from './_mocks';
 
 import gql from 'graphql-tag';
+import ApolloClient from 'apollo-client';
 
 import 'rxjs/add/operator/map';
 
@@ -26,17 +31,23 @@ const data = {
 };
 
 describe('ApolloQueryObservable', () => {
+  let apolloRef: ObservableQueryRef;
   let obsApollo;
-  let obsQuery;
-  let client;
+  let obsQuery: ApolloQueryObservable<any>;
+  let client: ApolloClient;
 
   beforeEach(() => {
     client = mockClient({
       request: { query },
       result: { data },
     });
+    apolloRef = new ObservableQueryRef();
     obsApollo = client.watchQuery({ query });
-    obsQuery = new ApolloQueryObservable(obsApollo);
+    apolloRef.apollo = obsApollo;
+    obsQuery = new ApolloQueryObservable(apolloRef, subscriber => {
+      const sub = obsApollo.subscribe(subscriber);
+      return () => sub.unsubscribe();
+    });
   });
 
   describe('regular', () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -4,6 +4,7 @@ import 'reflect-metadata';
 
 // tests
 import './angular2Apollo';
+import './utils';
 import './apolloQueryObservable';
 import './apolloQueryPipe';
-import './apolloDecorator/index';
+import './apolloDecorator';

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,0 +1,1 @@
+import './observeVariables';

--- a/tests/utils/observeVariables.ts
+++ b/tests/utils/observeVariables.ts
@@ -1,0 +1,61 @@
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/switch';
+
+import { observeVariables } from '../../src/utils/observeVariables';
+
+describe('observeVariables', () => {
+  it('should be able to subscribe to all Subjects', (done) => {
+    const variables = {
+      foo: new Subject(),
+      bar: new Subject(),
+    };
+
+    observeVariables(variables).subscribe(values => {
+      expect(values).toEqual({
+        foo: 'fooV',
+        bar: 'barV',
+      });
+      done();
+    });
+
+    variables.foo.next('fooV');
+    variables.bar.next('barV');
+  });
+
+  it('should be able to handle no Subjects', (done) => {
+    const variables = {
+      foo: 'fooV',
+      bar: 'barV',
+    };
+
+    observeVariables(variables).subscribe(values => {
+      expect(values).toEqual({
+        foo: 'fooV',
+        bar: 'barV',
+      });
+      done();
+    });
+  });
+
+  it('should be able to handle values mixed with Subjects and undefined', (done) => {
+    const variables = {
+      foo: 'fooV',
+      bar: new Subject(),
+      baz: undefined,
+    };
+
+    observeVariables(variables).subscribe(values => {
+      expect(values).toEqual({
+        foo: 'fooV',
+        bar: 'barV',
+        baz: undefined,
+      });
+      done();
+    });
+
+    variables.bar.next('barV');
+  });
+});


### PR DESCRIPTION
Closes #62

- [x] docs apollostack/docs#173

Example:

```ts
import { Subject } from 'rxjs/Subject';

const name = new Subject();
const city = new Subject();
const obs = client.watchQuery({
  query, 
  variables: {
    name,
    city
  }
});

obs.subscribe(result => {
  console.log(result);
});

// waits for values to be emitted

name.next('Kamil');

// still waits

city.next('Warsaw'); // build the query with { name: 'Kamil', city: 'Warsaw' }

city.next('Cracow'); // rebuild the query with { name: 'Kamil', city: 'Cracow' }
```