### PR TITLE
chore: Add unnecessary things to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,13 @@
-examples
+.github
 build/tests
+examples
+src
+tests
+typings
+.travis.yml
+.typingsrc
+global.d.ts
+karma.conf.js
+tsconfig.json
+tslint.json
+typings.json


### PR DESCRIPTION
Currently `node_modules/angular2-apollo` is a garbage.