### PR TITLE
fix: cannot subscribe on watchQuery without variables

### DIFF
--- a/src/Angular2Apollo.ts
+++ b/src/Angular2Apollo.ts
@@ -43,7 +43,9 @@ export class Angular2Apollo {
     }
 
     apolloRef.apollo = this.client.watchQuery(options);
-    return new ApolloQueryObservable(apolloRef);
+    return new ApolloQueryObservable(apolloRef, subscriber => {
+        return apolloRef.apollo.subscribe(subscriber).unsubscribe;
+    })
   }
 
   public query(options) {

--- a/tests/Angular2Apollo.ts
+++ b/tests/Angular2Apollo.ts
@@ -79,6 +79,15 @@ describe('angular2Apollo', () => {
         expect(client.watchQuery).toHaveBeenCalledWith(options);
       });
 
+      it('should be able to use obserable without variable', (done) => {
+        angular2Apollo
+          .watchQuery({ query })
+          .map(result => result.data)
+          .subscribe((result) => {
+              done();
+          });
+      });
+
       it('should be able to use obserable variable', (done) => {
         const variables = {
           foo: new Subject(),


### PR DESCRIPTION
This fixes(+ Tests) the bug i've reported (#76)