### PR TITLE
SelectPipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Made queries reusable (use refetch on new variables) ([PR #74](https://github.com/apollostack/angular2-apollo/pull/74))
 - Used [`apollo-client-rxjs`](https://github.com/kamilkisiela/apollo-client-rxjs) ([PR #72](https://github.com/apollostack/angular2-apollo/pull/72))
 - Fixed an issue that prevents from subscribing to `ApolloQueryObservable` ([PR #71](https://github.com/apollostack/angular2-apollo/pull/71))
+- Added `SelectPipe` and deprecated `ApolloQueryPipe` ([PR #78](https://github.com/apollostack/angular2-apollo/pull/78))
 
 ### v0.4.3
 

--- a/src/ApolloModule.ts
+++ b/src/ApolloModule.ts
@@ -1,11 +1,23 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { angularApolloClient, Angular2Apollo } from './Angular2Apollo';
+import { ApolloQueryPipe } from './ApolloQueryPipe';
+import { SelectPipe } from './SelectPipe';
 
 import ApolloClient from 'apollo-client';
 
+const APOLLO_DIRECTIVES = [
+  ApolloQueryPipe,
+  SelectPipe,
+];
+const APOLLO_PROVIDERS = [
+  Angular2Apollo,
+];
+
 @NgModule({
-  providers: [Angular2Apollo],
+  providers: APOLLO_PROVIDERS,
+  declarations: APOLLO_DIRECTIVES,
+  exports: APOLLO_DIRECTIVES,
 })
 export class ApolloModule {
   public static withClient(client: ApolloClient): ModuleWithProviders {

--- a/src/ApolloQueryPipe.ts
+++ b/src/ApolloQueryPipe.ts
@@ -3,6 +3,9 @@ import { Pipe } from '@angular/core';
 @Pipe({
   name: 'apolloQuery',
 })
+/**
+ * @deprecated since version 0.4.4 - use SelectPipe
+ */
 export class ApolloQueryPipe {
   public transform(obj: any, name: string = '') {
     if (obj && name !== '') {

--- a/src/SelectPipe.ts
+++ b/src/SelectPipe.ts
@@ -1,0 +1,8 @@
+import { Pipe } from '@angular/core';
+
+import { ApolloQueryPipe } from './ApolloQueryPipe';
+
+@Pipe({
+  name: 'select',
+})
+export class SelectPipe extends ApolloQueryPipe {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { ApolloQueryPipe } from './ApolloQueryPipe';
+import { SelectPipe } from './SelectPipe';
 import { Apollo, ApolloQuery } from './ApolloDecorator';
 import { Angular2Apollo, defaultApolloClient } from './Angular2Apollo';
 import { ApolloQueryObservable } from './ApolloQueryObservable';
@@ -14,6 +15,7 @@ export {
   ApolloQuery,
   ApolloQueryObservable,
   ApolloQueryPipe,
+  SelectPipe,
   Angular2Apollo,
   defaultApolloClient
 };

--- a/tests/ApolloQueryPipe.ts
+++ b/tests/ApolloQueryPipe.ts
@@ -1,39 +1,40 @@
-import { ApolloQueryPipe } from '../src';
+import { ApolloQueryPipe, SelectPipe } from '../src';
 
-describe('ApolloQueryPipe', () => {
-  let pipe: ApolloQueryPipe;
+const pipes: ApolloQueryPipe[] = [
+    new ApolloQueryPipe(),
+    new SelectPipe(),
+  ];
 
-  beforeEach(() => {
-    pipe = new ApolloQueryPipe();
+pipes.forEach(pipe => {
+  describe(pipe.constructor['name'], () => {
+    it('should return nothing if name is empty', () => {
+      expect(pipe.transform({ foo: 'bar' }, '')).toBe(undefined);
+    });
+    
+    it('should return nothing if object is empty', () => {
+      expect(pipe.transform({}, 'foo')).toBe(undefined);
+    });
+
+    it('should return nothing if object is missing', () => {
+      expect(pipe.transform(undefined, 'foo')).toBe(undefined);
+    });
+
+    it('should return nothing if nothing has been found', () => {
+      expect(pipe.transform({ foo: 'bar' }, 'baz')).toBe(undefined);
+    });
+
+    it('should be looking directly on object if the result comes from Apollo decorator', () => {
+      const result = { foo: 'bar' };
+
+      expect(pipe.transform(result, 'foo')).toEqual(result.foo);
+    });
+
+    it('should be looking inside data property iif the result comes fromf Angular2Apollo', () => {
+      const result = {
+        data: { foo: 'bar' },
+      };
+
+      expect(pipe.transform(result, 'foo')).toEqual(result.data.foo);
+    });
   });
-
-  it('should return nothing if name is empty', () => {
-    expect(pipe.transform({ foo: 'bar' }, '')).toBe(undefined);
-  });
-
-  it('should return nothing if object is empty', () => {
-    expect(pipe.transform({}, 'foo')).toBe(undefined);
-  });
-
-  it('should return nothing if object is missing', () => {
-    expect(pipe.transform(undefined, 'foo')).toBe(undefined);
-  });
-
-  it('should return nothing if nothing has been found', () => {
-    expect(pipe.transform({ foo: 'bar' }, 'baz')).toBe(undefined);
-  });
-
-  it('should be looking directly on object if the result comes from Apollo decorator', () => {
-    const result = { foo: 'bar' };
-
-    expect(pipe.transform(result, 'foo')).toEqual(result.foo);
-  });
-
-  it('should be looking inside data property iif the result comes fromf Angular2Apollo', () => {
-    const result = {
-      data: { foo: 'bar' },
-    };
-
-    expect(pipe.transform(result, 'foo')).toEqual(result.data.foo);
-  });
-});
+})


### PR DESCRIPTION
Also deprecate `ApolloQueryPipe`

---

Usage:

```html
<div *ngFor="let user of data | async | select: 'users'">{{ user.id }}</div>
```

Feels more natural than `apolloQuery: 'users'`.

---

@Urigo People can avoid using this pipe by simply using `map` operator but let's give them opportunity to choose between those options.