### PR TITLE
chore: include chai typings (#106)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@angular/core": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
+    "@types/chai": "^3.4.33",
     "@types/isomorphic-fetch": "0.0.30",
     "@types/jasmine": "^2.2.33",
     "@types/lodash": "^4.14.34",


### PR DESCRIPTION
Fixes for me issue #106, needed the chai typings file for `npm install` to run correctly.