### PR TITLE
chore: typings fix for example

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -44,7 +44,6 @@
     "express": "^4.14.0",
     "graphql": "^0.7.0",
     "graphql-tools": "^0.6.5",
-    "graphql-typings": "0.0.1-beta-2",
     "nodemon": "^1.10.2",
     "ts-node": "1.2.1",
     "tslint": "3.13.0",

--- a/examples/hello-world/src/typings.d.ts
+++ b/examples/hello-world/src/typings.d.ts
@@ -2,5 +2,4 @@
 // https://github.com/typings/typings
 // https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html
 
-/// <reference types="graphql-typings" />
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@angular/core": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
+    "@types/chai": "^3.4.33",
     "@types/isomorphic-fetch": "0.0.30",
     "@types/jasmine": "^2.2.33",
     "@types/lodash": "^4.14.34",


### PR DESCRIPTION
I was getting some errors of duplicate typings, and realized the problem had to do with graphql-typings, which is no longer needed, it seems.