### PR TITLE
Change default client provider to be a factory returning a default client

### DIFF
--- a/src/Angular2Apollo.ts
+++ b/src/Angular2Apollo.ts
@@ -1,4 +1,4 @@
-import { OpaqueToken, Injectable, Inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { rxify } from 'apollo-client-rxjs';
 import { ApolloClient, ApolloQueryResult, WatchQueryOptions, MutationOptions, SubscriptionOptions } from 'apollo-client';
 import { Observable } from 'rxjs/Observable';
@@ -13,19 +13,9 @@ export interface DeprecatedWatchQueryOptions extends WatchQueryOptions {
   fragments?: FragmentDefinition[];
 }
 
-export const angularApolloClient = new OpaqueToken('AngularApolloClient');
-export function defaultApolloClient(client: ApolloClient): any {
-  return {
-    provide: angularApolloClient,
-    useValue: client,
-  };
-}
-
 @Injectable()
 export class Angular2Apollo {
-  constructor(
-    @Inject(angularApolloClient) private client: any,
-  ) {}
+  constructor(private client: ApolloClient) {}
 
   public watchQuery(options: DeprecatedWatchQueryOptions): ApolloQueryObservable<ApolloQueryResult> {
     return new ApolloQueryObservable(rxify(this.client.watchQuery)(options));

--- a/src/ApolloModule.ts
+++ b/src/ApolloModule.ts
@@ -1,14 +1,22 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ApolloClient } from 'apollo-client';
 
-import { Angular2Apollo, defaultApolloClient } from './Angular2Apollo';
+import { Angular2Apollo } from './Angular2Apollo';
 import { SelectPipe } from './SelectPipe';
+
+export function getDefaultClient() {
+  return new ApolloClient();
+}
 
 const APOLLO_DIRECTIVES = [
   SelectPipe,
 ];
 const APOLLO_PROVIDERS = [
   Angular2Apollo,
+  {
+    provide: ApolloClient,
+    useFactory: getDefaultClient,
+  },
 ];
 
 @NgModule({
@@ -16,13 +24,4 @@ const APOLLO_PROVIDERS = [
   declarations: APOLLO_DIRECTIVES,
   exports: APOLLO_DIRECTIVES,
 })
-export class ApolloModule {
-  public static withClient(client: ApolloClient): ModuleWithProviders {
-    return {
-      ngModule: ApolloModule,
-      providers: [
-        defaultApolloClient(client),
-      ],
-    };
-  }
-}
+export class ApolloModule { }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { SelectPipe } from './SelectPipe';
-import { Angular2Apollo, defaultApolloClient } from './Angular2Apollo';
+import { Angular2Apollo } from './Angular2Apollo';
 import { ApolloQueryObservable } from './ApolloQueryObservable';
 import { ApolloModule } from './ApolloModule';
 
@@ -12,5 +12,4 @@ export {
   ApolloQueryObservable,
   SelectPipe,
   Angular2Apollo,
-  defaultApolloClient
 };

--- a/tests/Angular2Apollo.spec.ts
+++ b/tests/Angular2Apollo.spec.ts
@@ -6,7 +6,7 @@ import { RxObservableQuery } from 'apollo-client-rxjs';
 
 import { mockClient } from './_mocks';
 import { APOLLO_PROVIDERS } from '../src/index';
-import { Angular2Apollo, defaultApolloClient, angularApolloClient } from '../src/Angular2Apollo';
+import { Angular2Apollo } from '../src/Angular2Apollo';
 
 import gql from 'graphql-tag';
 
@@ -66,7 +66,7 @@ describe('angular2Apollo', () => {
     let angular2Apollo;
 
     beforeEach(() => {
-      const injector = ReflectiveInjector.resolveAndCreate([defaultApolloClient(client), APOLLO_PROVIDERS]);
+      const injector = ReflectiveInjector.resolveAndCreate([APOLLO_PROVIDERS]);
       angular2Apollo = injector.get(Angular2Apollo);
     });
 
@@ -240,14 +240,6 @@ describe('angular2Apollo', () => {
           },
         });
       });
-    });
-  });
-
-  describe('defaultApolloClient', () => {
-
-    it('should set a AngularApolloClient', () => {
-      const injector = ReflectiveInjector.resolveAndCreate([defaultApolloClient(client)]);
-      expect(injector.get(angularApolloClient)).toBe(client);
     });
   });
 });

--- a/tests/ApolloModule.spec.ts
+++ b/tests/ApolloModule.spec.ts
@@ -1,9 +1,6 @@
-import { ApolloClient } from 'apollo-client';
-
 import './_common';
 
 import { ApolloModule, SelectPipe, Angular2Apollo } from '../src';
-import { angularApolloClient } from '../src/Angular2Apollo';
 
 describe('ApolloModule', () => {
   let metadata: any = ApolloModule['decorators'][0]['args'][0];
@@ -22,27 +19,6 @@ describe('ApolloModule', () => {
 
   it('should contain Angular2Apollo in providers', () => {
     expect(include(metadata.exports, Angular2Apollo)).toBe(false);
-  });
-
-  it('should has withClient method', () => {
-    expect(ApolloModule.withClient).toBeDefined();
-  });
-
-  describe('withClient', () => {
-    const client = {} as ApolloClient;
-    const result = ApolloModule.withClient(client);
-
-    it('should contain ApolloModule as ngModule', () => {
-      expect(result.ngModule).toBe(ApolloModule);
-    });
-
-    it('should contain provider with useValue', () => {
-      expect(result.providers[0]['useValue']).toBe(client);
-    });
-
-    it('should contain provider that provide angularApolloClient', () => {
-      expect(result.providers[0]['provide']).toBe(angularApolloClient);
-    });
   });
 });
 


### PR DESCRIPTION
In order to support the latest version the angular compiler, I had to change the provider of client to be a factory provider.

New usage:
```ts
import { ApolloClient, createNetworkInterface } from 'apollo-client';
import { ApolloModule } from 'angular2-apollo';

export function getClient() {
  return new ApolloClient({
    networkInterface: createNetworkInterface({
      uri: environment.graphQL
    }),
  });
}

@NgModule({
  imports: [
    ApolloModule,
  ],
  providers: [
    {
      provide: ApolloClient,
      useFactory: getClient,
    },
  ],
})
export class AppModule { }

```

Also removed the need for an opaque token to be created. Why not just use { ApolloClient } as the provider token, as it is what you're importing anyway.

Closes #177