### PR TITLE
Release v0.9.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+### v0.9.0-rc.1
+
 - Support `es6` modules and `tree-shaking` ([PR #151](https://github.com/apollostack/angular2-apollo/pull/151))
 - Make our `Ahead-of-Time` compilation compatible with Angular 2.3.0 ([PR #189](https://github.com/apollostack/angular2-apollo/pull/189), [PR #195](https://github.com/apollostack/angular2-apollo/pull/195))
 - Added `getClient()` that exposes an instance of ApolloClient ([PR #203](https://github.com/apollostack/angular2-apollo/pull/203))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### v0.9.0-rc.1
 
 - Support `es6` modules and `tree-shaking` ([PR #151](https://github.com/apollostack/angular2-apollo/pull/151))
-- Make our `Ahead-of-Time` compilation compatible with Angular 2.3.0 ([PR #189](https://github.com/apollostack/angular2-apollo/pull/189), [PR #195](https://github.com/apollostack/angular2-apollo/pull/195))
+- Make our `Ahead-of-Time` compilation compatible with Angular 2.3+ ([PR #189](https://github.com/apollostack/angular2-apollo/pull/189), [PR #195](https://github.com/apollostack/angular2-apollo/pull/195))
 - Added `getClient()` that exposes an instance of ApolloClient ([PR #203](https://github.com/apollostack/angular2-apollo/pull/203))
+- **BREAKING CHANGE** The way to provide an instance of ApolloClient has changed, [see how](https://github.com/apollostack/angular2-docs/pull/23)
 
 ### v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support `es6` modules and `tree-shaking` ([PR #151](https://github.com/apollostack/angular2-apollo/pull/151))
 - Make our `Ahead-of-Time` compilation compatible with Angular 2.3.0 ([PR #189](https://github.com/apollostack/angular2-apollo/pull/189), [PR #195](https://github.com/apollostack/angular2-apollo/pull/195))
+- Added `getClient()` that exposes an instance of ApolloClient ([PR #203](https://github.com/apollostack/angular2-apollo/pull/203))
 
 ### v0.8.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-apollo",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "description": "Angular 2.0 client for Apollo",
   "main": "build/bundles/apollo.umd.js",
   "module": "build/src/index.js",


### PR DESCRIPTION
@Urigo I think we should publish it first as a Release Candidate because of this UMD thing and updated AoT compilation

- [x] #195
- [ ] #206
- [ ] apollostack/angular2-docs#23