### PR TITLE
Remove types of node and isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "apollo-client": "^0.6.0",
-    "rxjs": "^5.0.0-beta.12 || ^5.0.0-rc.1 || 5.0.0"
+    "rxjs": "^5.0.0-beta.12 || ^5.0.0-rc.1 || ^5.0.0"
   },
   "dependencies": {
     "apollo-client-rxjs": "~0.3.0"
@@ -47,14 +47,11 @@
     "@angular/platform-browser": "^2.3.1",
     "@angular/platform-browser-dynamic": "^2.3.1",
     "@angular/platform-server": "^2.3.1",
-    "@types/chai": "^3.4.34",
-    "@types/isomorphic-fetch": "^0.0.30",
     "@types/jest": "^15.1.32",
     "@types/lodash": "^4.14.34",
-    "@types/node": "^6.0.38",
     "apollo-client": "^0.6.0",
     "graphql": "^0.8.2",
-    "graphql-tag": "^1.0.0",
+    "graphql-tag": "^1.1.2",
     "husky": "^0.12.0",
     "jest": "^17.0.0",
     "reflect-metadata": "^0.1.8",


### PR DESCRIPTION
No longer needed thanks to recent changes of apollo-client